### PR TITLE
Allowing all-auth templates to be modified

### DIFF
--- a/Apps/SoundScapeApp/Templates/Home.html
+++ b/Apps/SoundScapeApp/Templates/Home.html
@@ -1,3 +1,13 @@
-<h1>Welcome to the Music Web App!</h1>
-<p>Already have an account? <a href="{% url 'account_login' %}">Log in</a></p>
-<p>Don't have an account? <a href="{% url 'account_signup' %}">Sign up</a></p>
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>{% block title %}My Site{% endblock %}</title>
+        {% load static %}
+        <link rel="stylesheet" href="{% static 'CSS/topartists.css' %}">
+    </head>
+    <body>
+        <h1>Welcome to the Music Web App!</h1>
+        <p>Already have an account? <a href="{% url 'account_login' %}">Log in</a></p>
+        <p>Don't have an account? <a href="{% url 'account_signup' %}">Sign up</a></p>
+    </body>
+</html>

--- a/Apps/SoundScapeApp/Templates/account/login.html
+++ b/Apps/SoundScapeApp/Templates/account/login.html
@@ -1,4 +1,4 @@
-{% extends "account/base_entrance.html" %}
+
 {% load static %}
 {% load allauth i18n %}
 {% block head_title %}

--- a/Apps/SoundScapeApp/Templates/account/login.html
+++ b/Apps/SoundScapeApp/Templates/account/login.html
@@ -1,50 +1,18 @@
+{% extends "base.html" %}
 
-{% load static %}
-{% load allauth i18n %}
-{% block head_title %}
-    {% trans "Signup" %}
-{% endblock head_title %}
-{% block head %}
-    {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static 'CSS/index.css' %}">
-{% endblock head %}
+{% load i18n %}
+
 {% block content %}
-    {% element h1 %}
-        {% trans "Sign Up" %}
-    {% endelement %}
-    {% setvar link %}
-        <a href="{{ login_url }}">
-    {% endsetvar %}
-{% setvar end_link %}
-    </a>
-{% endsetvar %}
-    {% element p %}
-        {% blocktranslate %}Already have an account? Then please {{ link }}sign in{{ end_link }}.{% endblocktranslate %}
-    {% endelement %}
-    {% if not SOCIALACCOUNT_ONLY %}
-        {% url 'account_signup' as action_url %}
-        {% element form form=form method="post" action=action_url tags="entrance,signup" %}
-            {% slot body %}
-                {% csrf_token %}
-                {% element fields form=form unlabeled=True %}
-                {% endelement %}
-                {{ redirect_field }}
-            {% endslot %}
-            {% slot actions %}
-                {% element button tags="prominent,signup" type="submit" %}
-                    {% trans "Sign Up" %}
-                {% endelement %}
-            {% endslot %}
-        {% endelement %}
-    {% endif %}
-    {% if PASSKEY_SIGNUP_ENABLED %}
-        {% element hr %}
-        {% endelement %}
-        {% element button href=signup_by_passkey_url tags="prominent,signup,outline,primary" %}
-            {% trans "Sign up using a passkey" %}
-        {% endelement %}
-    {% endif %}
-    {% if SOCIALACCOUNT_ENABLED %}
-        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
-    {% endif %}
-{% endblock content %}
+    <div class="form-container">
+        <h1>{% trans "Log In" %}</h1>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit" class="btn btn-primary">{% trans "Log In" %}</button>
+        </form>
+        <p>
+            {% trans "Don't have an account?" %}
+            <a href="{% url 'account_signup' %}">{% trans "Sign Up here" %}</a>.
+        </p>
+    </div>
+{% endblock %}

--- a/Apps/SoundScapeApp/Templates/account/login.html
+++ b/Apps/SoundScapeApp/Templates/account/login.html
@@ -1,0 +1,50 @@
+{% extends "account/base_entrance.html" %}
+{% load static %}
+{% load allauth i18n %}
+{% block head_title %}
+    {% trans "Signup" %}
+{% endblock head_title %}
+{% block head %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static 'CSS/index.css' %}">
+{% endblock head %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Sign Up" %}
+    {% endelement %}
+    {% setvar link %}
+        <a href="{{ login_url }}">
+    {% endsetvar %}
+{% setvar end_link %}
+    </a>
+{% endsetvar %}
+    {% element p %}
+        {% blocktranslate %}Already have an account? Then please {{ link }}sign in{{ end_link }}.{% endblocktranslate %}
+    {% endelement %}
+    {% if not SOCIALACCOUNT_ONLY %}
+        {% url 'account_signup' as action_url %}
+        {% element form form=form method="post" action=action_url tags="entrance,signup" %}
+            {% slot body %}
+                {% csrf_token %}
+                {% element fields form=form unlabeled=True %}
+                {% endelement %}
+                {{ redirect_field }}
+            {% endslot %}
+            {% slot actions %}
+                {% element button tags="prominent,signup" type="submit" %}
+                    {% trans "Sign Up" %}
+                {% endelement %}
+            {% endslot %}
+        {% endelement %}
+    {% endif %}
+    {% if PASSKEY_SIGNUP_ENABLED %}
+        {% element hr %}
+        {% endelement %}
+        {% element button href=signup_by_passkey_url tags="prominent,signup,outline,primary" %}
+            {% trans "Sign up using a passkey" %}
+        {% endelement %}
+    {% endif %}
+    {% if SOCIALACCOUNT_ENABLED %}
+        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+    {% endif %}
+{% endblock content %}

--- a/Apps/SoundScapeApp/Templates/account/signup.html
+++ b/Apps/SoundScapeApp/Templates/account/signup.html
@@ -1,50 +1,18 @@
-{% extends "account/base_entrance.html" %}
-{% load static %}
-{% load allauth i18n %}
-{% block head_title %}
-    {% trans "Signup" %}
-{% endblock head_title %}
-{% block head %}
-    {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static 'CSS/base.css' %}">
-{% endblock head %}
+{% extends "base.html" %}
+
+{% load i18n %}
+
 {% block content %}
-    {% element h1 %}
-        {% trans "Sign Up" %}
-    {% endelement %}
-    {% setvar link %}
-        <a href="{{ login_url }}">
-    {% endsetvar %}
-{% setvar end_link %}
-    </a>
-{% endsetvar %}
-    {% element p %}
-        {% blocktranslate %}Already have an account? Then please {{ link }}sign in{{ end_link }}.{% endblocktranslate %}
-    {% endelement %}
-    {% if not SOCIALACCOUNT_ONLY %}
-        {% url 'account_signup' as action_url %}
-        {% element form form=form method="post" action=action_url tags="entrance,signup" %}
-            {% slot body %}
-                {% csrf_token %}
-                {% element fields form=form unlabeled=True %}
-                {% endelement %}
-                {{ redirect_field }}
-            {% endslot %}
-            {% slot actions %}
-                {% element button tags="prominent,signup" type="submit" %}
-                    {% trans "Sign Up" %}
-                {% endelement %}
-            {% endslot %}
-        {% endelement %}
-    {% endif %}
-    {% if PASSKEY_SIGNUP_ENABLED %}
-        {% element hr %}
-        {% endelement %}
-        {% element button href=signup_by_passkey_url tags="prominent,signup,outline,primary" %}
-            {% trans "Sign up using a passkey" %}
-        {% endelement %}
-    {% endif %}
-    {% if SOCIALACCOUNT_ENABLED %}
-        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
-    {% endif %}
-{% endblock content %}
+    <div class="form-container">
+        <h1>{% trans "Sign Up" %}</h1>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type="submit" class="btn btn-primary">{% trans "Sign Up" %}</button>
+        </form>
+        <p>
+            {% trans "Already have an account?" %}
+            <a href="{% url 'account_login' %}">{% trans "Log In here" %}</a>.
+        </p>
+    </div>
+{% endblock %}

--- a/Apps/SoundScapeApp/Templates/account/signup.html
+++ b/Apps/SoundScapeApp/Templates/account/signup.html
@@ -1,0 +1,50 @@
+{% extends "account/base_entrance.html" %}
+{% load static %}
+{% load allauth i18n %}
+{% block head_title %}
+    {% trans "Signup" %}
+{% endblock head_title %}
+{% block head %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static 'CSS/base.css' %}">
+{% endblock head %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Sign Up" %}
+    {% endelement %}
+    {% setvar link %}
+        <a href="{{ login_url }}">
+    {% endsetvar %}
+{% setvar end_link %}
+    </a>
+{% endsetvar %}
+    {% element p %}
+        {% blocktranslate %}Already have an account? Then please {{ link }}sign in{{ end_link }}.{% endblocktranslate %}
+    {% endelement %}
+    {% if not SOCIALACCOUNT_ONLY %}
+        {% url 'account_signup' as action_url %}
+        {% element form form=form method="post" action=action_url tags="entrance,signup" %}
+            {% slot body %}
+                {% csrf_token %}
+                {% element fields form=form unlabeled=True %}
+                {% endelement %}
+                {{ redirect_field }}
+            {% endslot %}
+            {% slot actions %}
+                {% element button tags="prominent,signup" type="submit" %}
+                    {% trans "Sign Up" %}
+                {% endelement %}
+            {% endslot %}
+        {% endelement %}
+    {% endif %}
+    {% if PASSKEY_SIGNUP_ENABLED %}
+        {% element hr %}
+        {% endelement %}
+        {% element button href=signup_by_passkey_url tags="prominent,signup,outline,primary" %}
+            {% trans "Sign up using a passkey" %}
+        {% endelement %}
+    {% endif %}
+    {% if SOCIALACCOUNT_ENABLED %}
+        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+    {% endif %}
+{% endblock content %}

--- a/Apps/SoundScapeApp/Templates/base.html
+++ b/Apps/SoundScapeApp/Templates/base.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{% block title %}My Site{% endblock %}</title>
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'CSS/topartists.css' %}">
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/static/CSS/topartists.css
+++ b/static/CSS/topartists.css
@@ -21,12 +21,12 @@ html, body {
 
 /* unvisited link */
 a:link {
-    color: #000000;
+    color: #ffffff;
 }
 
 /* visited link */
 a:visited {
-    color: #000000;
+    color: #ffffff;
 }
 
 /* mouse over link */


### PR DESCRIPTION
Creating the all-auth templates so that they can be modified, where basic CSS has been applied. Future CSS improvements will be done, and the logout screen. This purpose of this PR to allow the ability for the templates to be modified.

<img width="1710" alt="Screenshot 2025-01-19 at 9 14 13 AM" src="https://github.com/user-attachments/assets/3efc2ef6-d863-407e-ace0-b06948512cd8" />
<img width="1710" alt="Screenshot 2025-01-19 at 9 14 29 AM" src="https://github.com/user-attachments/assets/b5cd7da0-5ac2-4d33-ab4c-98336bb08149" />
<img width="1710" alt="Screenshot 2025-01-19 at 9 14 38 AM" src="https://github.com/user-attachments/assets/4aa52e6b-4d2f-4d67-9d9a-7d80464975bb" />
